### PR TITLE
Fix issue where game will not reset on a new day

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
   const [isRevealing, setIsRevealing] = useState(false)
   const [guesses, setGuesses] = useState<string[]>(() => {
     const loaded = loadGameStateFromLocalStorage()
-    if (loaded?.solution !== solution) {
+    if (loaded?.date !== new Date().getDate()) {
       return []
     }
     const gameWasWon = loaded.guesses.includes(solution)
@@ -149,7 +149,11 @@ function App() {
   }
 
   useEffect(() => {
-    saveGameStateToLocalStorage({ guesses, solution })
+    saveGameStateToLocalStorage({
+      guesses,
+      solution,
+      date: new Date().getDate(),
+    })
   }, [guesses])
 
   useEffect(() => {

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -3,7 +3,8 @@ const highContrastKey = 'highContrast'
 
 type StoredGameState = {
   guesses: string[]
-  solution: string
+  solution: string,
+  date: number,
 }
 
 export const saveGameStateToLocalStorage = (gameState: StoredGameState) => {


### PR DESCRIPTION
Previously the game would be checking if today's solution is different from yesterday. Since the solution doesn't change in bazzingle, that doesn't work. This modifies the change to be based on the getDate value from the JS date.

Note: This introduces the bug where if a player rejoins after a month, the game will not be reset.